### PR TITLE
Fix typos in descriptions of quiet options

### DIFF
--- a/scripts/compare-dirs
+++ b/scripts/compare-dirs
@@ -49,7 +49,7 @@ parser = OptionParser(usage=usage)
 parser.add_option('-v', '--verbose', action='count', dest='v', default=0,
                   help='Make more noise')
 parser.add_option('-q', '--quiet', action='count', dest='q', default=0,
-                  help='Make more noise')
+                  help='Make less noise')
 parser.add_option('-m', '--merge',
                   help='Use this directory to stage merged files')
 

--- a/scripts/compare-locales
+++ b/scripts/compare-locales
@@ -51,7 +51,7 @@ parser = OptionParser(usage = usage, version = "%%prog %s" % version)
 parser.add_option('-v', '--verbose', action='count', dest='v', default=0,
                   help='Make more noise')
 parser.add_option('-q', '--quiet', action='count', dest='q', default=0,
-                  help='Make more noise')
+                  help='Make less noise')
 parser.add_option('-r', '--reference', default='en-US', dest='reference',
                   help='Explicitly set the reference '+
                   'localization. [default: en-US]')


### PR DESCRIPTION
This has been sitting dormant for over a year, apparently, but the changes still seem relevant.
